### PR TITLE
Change port table layout, fix currency return bug 

### DIFF
--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -10,6 +10,8 @@ export default class Navigation extends React.Component {
 
   render() {
 
+    const loggedIn = localStorage.getItem('token') ? true : false
+
     return (
       <div className="navbar">
         <Navbar inverse collapseOnSelect>
@@ -24,7 +26,8 @@ export default class Navigation extends React.Component {
           </Navbar.Header>
           <Navbar.Collapse>
 
-            {this.props.loggedIn ?
+            {/* {this.props.loggedIn ? */}
+            {loggedIn ?
             
             <Nav pullRight>
               <LinkContainer to='/portfolio'>

--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -1,16 +1,15 @@
 import React from 'react'
 import { Navbar, Nav, NavItem, NavDropdown, MenuItem } from 'react-bootstrap'
-import {Link} from 'react-router-dom';
-import { LinkContainer } from 'react-router-bootstrap';
+import {Link} from 'react-router-dom'
+import { LinkContainer } from 'react-router-bootstrap'
+import axios from 'axios'
 
 export default class Navigation extends React.Component {
   constructor(props) {
-    super(props);
+    super(props)
   }
 
   render() {
-
-    const loggedIn = localStorage.getItem('token') ? true : false
 
     return (
       <div className="navbar">
@@ -26,8 +25,7 @@ export default class Navigation extends React.Component {
           </Navbar.Header>
           <Navbar.Collapse>
 
-            {/* {this.props.loggedIn ? */}
-            {loggedIn ?
+            {this.props.loggedIn ?
             
             <Nav pullRight>
               <LinkContainer to='/portfolio'>

--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -4,7 +4,7 @@ import {Link} from 'react-router-dom'
 import { LinkContainer } from 'react-router-bootstrap'
 import axios from 'axios'
 
-export default class Navigation extends React.Component {
+export default class NavBar extends React.Component {
   constructor(props) {
     super(props)
   }

--- a/client/components/Simulator/PortfolioEntry.js
+++ b/client/components/Simulator/PortfolioEntry.js
@@ -6,6 +6,7 @@ export default class PortfolioEntry extends React.Component {
     this.state = {
       stockValue: this.props.stockValues[this.props.item.ticker],
       origValue: this.props.origValues[this.props.item.ticker],
+      sellValue: this.props.sellValues[this.props.item.ticker],
       stockReturn: 0,
       mixValue: ((parseFloat(props.stockValues[this.props.item.ticker]) / parseFloat(props.portfolioValue)) * 100).toFixed(2)
     }
@@ -41,8 +42,13 @@ export default class PortfolioEntry extends React.Component {
   }
 
   calculateCurrencyReturn() {
-    let stockReturn = this.state.origValue !== 0 ?
-   ((this.state.stockValue - this.state.origValue) / this.state.origValue*100).toFixed(2) : 0
+  //   let stockReturn = this.state.origValue !== 0 ?
+  //  ((this.state.stockValue - this.state.origValue) / this.state.origValue*100).toFixed(2) : 0
+
+  //   this.setState({ stockReturn })
+
+    let stockReturn = this.props.item.shares === 0 ? 0 :
+    (((this.state.stockValue + this.state.sellValue) - this.state.origValue) / this.state.origValue*100).toFixed(2)
 
     this.setState({ stockReturn })
   }

--- a/client/components/Simulator/PortfolioEntry.js
+++ b/client/components/Simulator/PortfolioEntry.js
@@ -42,11 +42,6 @@ export default class PortfolioEntry extends React.Component {
   }
 
   calculateCurrencyReturn() {
-  //   let stockReturn = this.state.origValue !== 0 ?
-  //  ((this.state.stockValue - this.state.origValue) / this.state.origValue*100).toFixed(2) : 0
-
-  //   this.setState({ stockReturn })
-
     let stockReturn = this.props.item.shares === 0 ? 0 :
     (((this.state.stockValue + this.state.sellValue) - this.state.origValue) / this.state.origValue*100).toFixed(2)
 
@@ -63,8 +58,8 @@ export default class PortfolioEntry extends React.Component {
 
     return (
       <tr>
-        <td>{this.getCurrencyName(this.props.item.ticker)} </td>
-        <td>{this.props.item.ticker} </td>
+        <td>{this.getCurrencyName(this.props.item.ticker)} ({this.props.item.ticker.toUpperCase()})</td>
+        {/* <td>{this.props.item.ticker.toUpperCase()} </td> */}
         <td>{Math.round(this.props.item.shares * 1000) / 1000} </td>
         <td>${this.state.stockValue} </td>
         <td>{isNaN(this.state.mixValue) ? '0.00' :  ((parseFloat(this.props.stockValues[this.props.item.ticker]) / parseFloat(this.props.portfolioValue)) * 100).toFixed(2)}%</td>

--- a/client/components/Simulator/PortfolioInfo.js
+++ b/client/components/Simulator/PortfolioInfo.js
@@ -267,8 +267,8 @@ export default class PortfolioInfo extends React.Component {
           <div className='col-xs-12 col-sm-4 portfolioDetails'>
             <h2>{this.state.portfolioName} <span className='rank'>&nbsp; Ranked: {this.state.portfolioRank}</span></h2>
             <p>Portfolio Value: ${this.state.portfolioValue}</p>
-            <p>Cash: ${this.state.cash}</p>
-            <p>Annual Return: {isNaN(this.state.annualReturn) ? 'Calculating...' : (Number(this.state.annualReturn) * 100).toFixed(2)}%</p>
+            <p>Remaining Cash: ${Number(this.state.cash).toFixed(2)}</p>
+            <p>Lifetime Return: {isNaN(this.state.annualReturn) ? 'Calculating...' : (Number(this.state.annualReturn) * 100).toFixed(2)}%</p>
             <Button bsSize="xsmall" onClick={this.handleTransactionModal}>Buy/Sell History</Button>
             <TransactionModal transactions={this.props.transactions} showModal={this.state.showModal} />
             <hr />

--- a/client/components/Simulator/PortfolioInfo.js
+++ b/client/components/Simulator/PortfolioInfo.js
@@ -233,7 +233,9 @@ export default class PortfolioInfo extends React.Component {
         maskColor: 'rgba(255,255,255,0.3)'
       };
       Highcharts.setOptions(Highcharts.theme);
-    if (this.state.history) {
+    if (data) {
+      data.sort((a,b) => a[0] > b[0] ? 1 : a[0] < b[0] ? -1 : 0);
+      console.log(data);
       Highcharts.stockChart('container', {
         rangeSelector: { 
           selected: 1 

--- a/client/components/Simulator/PortfolioInfo.js
+++ b/client/components/Simulator/PortfolioInfo.js
@@ -279,7 +279,7 @@ export default class PortfolioInfo extends React.Component {
           </div>
           <div className='col-xs-12 col-sm-8'>
             <PortfolioTable portfolioStocks={this.props.portfolioStocks} stockValues={this.props.stockValues} 
-              portfolioValue={this.props.portfolioValue} origValues={this.props.origValues}
+              portfolioValue={this.props.portfolioValue} origValues={this.props.origValues} sellValues={this.props.sellValues}
             />
           </div>
         </div>

--- a/client/components/Simulator/PortfolioLanding.js
+++ b/client/components/Simulator/PortfolioLanding.js
@@ -289,7 +289,6 @@ export default class PortfolioLanding extends React.Component {
           trackBackgroundColor: '#404043',
           trackBorderColor: '#404043'
       },
-      // special colors for some of the
       legendBackgroundColor: 'rgba(0, 0, 0, 0.5)',
       background2: '#505053',
       dataLabelsColor: '#B0B0B3',

--- a/client/components/Simulator/PortfolioLanding.js
+++ b/client/components/Simulator/PortfolioLanding.js
@@ -22,7 +22,7 @@ export default class PortfolioLanding extends React.Component {
       name: '',
       seriesOptions: [],
       seriesCounter: 0,
-      names: ['btc','bch','eth','ltc','xmr','xrp','zec']
+      names: ['btc','bch','eth','ltc','xmr','xrp']
     }
     this.handleFetchData = this.handleFetchData.bind(this)
     this.createPort = this.createPort.bind(this)

--- a/client/components/Simulator/PortfolioPage.js
+++ b/client/components/Simulator/PortfolioPage.js
@@ -25,7 +25,9 @@ export default class PortfolioPage extends React.Component {
       transactions: [],
       isOwner: false,
       origValues: {},
-      currValues: {}
+      currValues: {},
+      token: localStorage.getItem('token'),
+      loggedIn: false
     }
     this.checkForOwner = this.checkForOwner.bind(this)
     this.fetchPortfolioTransactions = this.fetchPortfolioTransactions.bind(this)
@@ -41,17 +43,34 @@ export default class PortfolioPage extends React.Component {
     this.isEmpty = this.isEmpty.bind(this)
     this.handleDelete = this.handleDelete.bind(this)
     this.calculateOriginalStockValues = this.calculateOriginalStockValues.bind(this)
+    this.authorize = this.authorize.bind(this)
     
   }
   componentDidMount() {
+    this.authorize()
     this.checkForOwner()
     this.fetchPortfolioTransactions()
   }
+
+  authorize() {
+    axios({
+      method: 'get',
+      url: '/api/loggedIn',
+      headers: {authorization: this.state.token}
+    })
+    .then(response => {
+      console.log(response.status)
+      const loggedIn = response.status === 200 ? true : false
+      this.setState({ loggedIn })
+    })
+    .catch(err => console.error(err))
+  }
+
   checkForOwner(){
     axios({
       method: 'get',
       url: '/api/isOwnerOfPortfolio',
-      headers: {authorization: localStorage.getItem('token')},
+      headers: {authorization: this.state.token},
       params: {portfolioId: this.state.portfolioId}
     })
     .then(reply => {
@@ -103,9 +122,6 @@ export default class PortfolioPage extends React.Component {
     const transactions = this.state.transactions
 
     for (let i = 0; i < transactions.length; i++) {
-      // transactions[i].transactionType === "buy" ? 
-      // origValues[transactions[i].ticker] += (transactions[i].shares*transactions[i].transactionPrice) : 
-      // origValues[transactions[i].ticker] -= (transactions[i].shares*transactions[i].transactionPrice)
 
       transactions[i].transactionType === "buy" ? 
       origValues[transactions[i].ticker] += (transactions[i].shares*transactions[i].transactionPrice) : 
@@ -281,7 +297,7 @@ export default class PortfolioPage extends React.Component {
   render() {
     return (
       <div className='container' id='portPage'>
-        <Navigation handleLogOut={this.handleLogOutAndRedirect} loggedIn={true} handleDelete={this.handleDelete} isOwner={this.state.isOwner}/> 
+        <Navigation handleLogOut={this.handleLogOutAndRedirect} loggedIn={this.state.loggedIn} handleDelete={this.handleDelete} isOwner={this.state.isOwner}/> 
         <PortfolioInfo totalPortfolios={this.state.totalPortfolios} portfolioRank={this.state.portfolioRank} portfolioStocks={this.state.portfolio.stocks} stockValues={this.state.stockValues} history={this.state.history} 
           portfolioValue={this.state.portfolioValue} cash={this.state.cash} portfolioName={this.state.portfolioName} 
           annualReturn={this.state.annualReturn} portfolioId ={this.state.portfolioId} portfolio = {this.state.portfolio} 

--- a/client/components/Simulator/PortfolioPage.js
+++ b/client/components/Simulator/PortfolioPage.js
@@ -24,7 +24,8 @@ export default class PortfolioPage extends React.Component {
       history: [],
       transactions: [],
       isOwner: false,
-      origValues: {}
+      origValues: {},
+      currValues: {}
     }
     this.checkForOwner = this.checkForOwner.bind(this)
     this.fetchPortfolioTransactions = this.fetchPortfolioTransactions.bind(this)
@@ -90,14 +91,27 @@ export default class PortfolioPage extends React.Component {
       'xmr': 0
     }
 
+    let sellValues = { 
+      'btc': 0,
+      'bch': 0,
+      'ltc': 0,
+      'eth': 0,
+      'xrp': 0,
+      'xmr': 0
+    }
+
     const transactions = this.state.transactions
 
     for (let i = 0; i < transactions.length; i++) {
+      // transactions[i].transactionType === "buy" ? 
+      // origValues[transactions[i].ticker] += (transactions[i].shares*transactions[i].transactionPrice) : 
+      // origValues[transactions[i].ticker] -= (transactions[i].shares*transactions[i].transactionPrice)
+
       transactions[i].transactionType === "buy" ? 
       origValues[transactions[i].ticker] += (transactions[i].shares*transactions[i].transactionPrice) : 
-      origValues[transactions[i].ticker] -= (transactions[i].shares*transactions[i].transactionPrice)
+      sellValues[transactions[i].ticker] += (transactions[i].shares*transactions[i].transactionPrice)
     }
-    this.setState({ origValues })
+    this.setState({ origValues, sellValues })
   }
   
   handleFetchData(){
@@ -273,7 +287,7 @@ export default class PortfolioPage extends React.Component {
           annualReturn={this.state.annualReturn} portfolioId ={this.state.portfolioId} portfolio = {this.state.portfolio} 
           portfolioBalance={this.state.cash} successfulBuy={this.successfulBuy} successfulSell={this.successfulSell}
           successfulPurge={this.successfulPurge} isOwner={this.state.isOwner} transactions = {this.state.transactions}
-          origValues={this.state.origValues}
+          origValues={this.state.origValues} sellValues={this.state.sellValues}
         />
       
         

--- a/client/components/Simulator/PortfolioTable.js
+++ b/client/components/Simulator/PortfolioTable.js
@@ -94,7 +94,12 @@ export default class PortfolioTable extends React.Component {
         <tbody>
           {this.state.entries ?
           this.state.entries.map((item, index) => (
-            this.state.stockValues[item.ticker] !== undefined ? <PortfolioEntry item={item} key={index} origValues={this.props.origValues} stockValues={this.state.stockValues} portfolioValue={this.state.portfolioValue} /> : null
+            this.state.stockValues[item.ticker] !== undefined ? 
+            <PortfolioEntry item={item} key={index} sellValues={this.props.sellValues} 
+            origValues={this.props.origValues} stockValues={this.state.stockValues} 
+            portfolioValue={this.state.portfolioValue} />
+            : 
+            null
           ))
           :
           null

--- a/client/components/Simulator/PortfolioTable.js
+++ b/client/components/Simulator/PortfolioTable.js
@@ -84,7 +84,7 @@ export default class PortfolioTable extends React.Component {
         <thead className='thead-default'>
           <tr>
             <th style={{ 'textAlign':'center' }}>Asset</th>
-            <th style={{ 'textAlign':'center' }}>Ticker</th>
+            {/* <th style={{ 'textAlign':'center' }}>Ticker</th> */}
             <th style={{ 'textAlign':'center' }}>Qty</th>
             <th style={{ 'textAlign':'center' }}>Value</th>
             <th style={{ 'textAlign':'center' }}>Mix</th>     

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -16,7 +16,7 @@ router.get('/getToken', auth.getToken);
 
 /////////
 
-
+router.get('/loggedIn', auth.authenticate, (req, res) => res.send('true'))
 
 router.get('/coinQuery', portfolioStock.coinQuery);
 

--- a/static/index.html
+++ b/static/index.html
@@ -2,6 +2,16 @@
 <html lang="en">
 
 <head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-107995831-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-107995831-1');
+  </script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">


### PR DESCRIPTION
Combine ticker and currency name in port table. Ex: Bitcoin (BTC) in one column instead of Bitcoin and BTC being in separate columns, taking up space.

Also, currency returns weren't being calculated correctly after selling something for a profit.